### PR TITLE
Fix link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You will have to:
 
 ----
 
-Still here? Ready to [get started](tutorials/setup_workspace.md)?
+Still here? Ready to [get started](https://hashistack.readthedocs.io/en/latest/tutorials/setup_workspace.html)?
 
 ----
 


### PR DESCRIPTION
setup workspace is now on readthedocs, update link accordingly