### PR TITLE
Add SCW_DEFAULT_PROJECT_ID to init_scw.md

### DIFF
--- a/docs/source/howto/init_scw.md
+++ b/docs/source/howto/init_scw.md
@@ -21,6 +21,7 @@ At the workspace root, create or edit a ``.env.secrets`` file with this content:
 :caption: .env.secrets
 :linenos:
 export SCW_DEFAULT_ORGANIZATION_ID="..."
+export SCW_DEFAULT_PROJECT_ID="..."
 export SCW_ACCESS_KEY="..."
 export SCW_SECRET_KEY="..."
 # This value is only an example


### PR DESCRIPTION
Fixes an error during scaleway mono deploy:

fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/root/hashistack/.direnv/bin/terraform apply -no-color -input=false -auto-approve -lock=true /tmp/tmp8v7c2ek2.tfplan", "msg": "\nError: scaleway-sdk-go: invalid argument(s): project_id is wrongly formatted, value must be a valid UUID\n\n  with scaleway_account_ssh_key.admin,\n  on main.tf line 13, in resource \"scaleway_account_ssh_key\" \"admin\":\n  13: resource \"scaleway_account_ssh_key\" \"admin\" {", "rc": 1, "stderr": "\nError: scaleway-sdk-go: invalid argument(s): project_id is wrongly formatted, value must be a valid UUID\n\n  with scaleway_account_ssh_key.admin,\n  on main.tf line 13, in resource \"scaleway_account_ssh_key\" \"admin\":\n  13: resource \"scaleway_account_ssh_key\" \"admin\" {\n\n", "stderr_lines": ["", "Error: scaleway-sdk-go: invalid argument(s): project_id is wrongly formatted, value must be a valid UUID", "", "  with scaleway_account_ssh_key.admin,", "  on main.tf line 13, in resource \"scaleway_account_ssh_key\" \"admin\":", "  13: resource \"scaleway_account_ssh_key\" \"admin\" {", ""], "stdout": "scaleway_account_ssh_key.admin: Creating...\nscaleway_instance_security_group.server: Creating...\nscaleway_instance_security_group.server: Creation complete after 2s [id=fr-par-2/d4860f29-343e-4c3f-b634-2c46ec916454]\nscaleway_instance_server.mono: Creating...\nscaleway_instance_server.mono: Still creating... [10s elapsed]\nscaleway_instance_server.mono: Creation complete after 18s [id=fr-par-2/a0464892-8a6e-4146-8ab0-260a6c08b361]\n", "stdout_lines": ["scaleway_account_ssh_key.admin: Creating...", "scaleway_instance_security_group.server: Creating...", "scaleway_instance_security_group.server: Creation complete after 2s [id=fr-par-2/d4860f29-343e-4c3f-b634-2c46ec916454]", "scaleway_instance_server.mono: Creating...", "scaleway_instance_server.mono: Still creating... [10s elapsed]", "scaleway_instance_server.mono: Creation complete after 18s [id=fr-par-2/a0464892-8a6e-4146-8ab0-260a6c08b361]"]}

Upd: it is mandatory
https://registry.terraform.io/providers/scaleway/scaleway/latest/docs#:~:text=SCW_DEFAULT_PROJECT_ID