### PR TITLE
fix(terraform): instance_type on scaleway mono

### DIFF
--- a/roles/stage0/files/scaleway_mono/main.tf
+++ b/roles/stage0/files/scaleway_mono/main.tf
@@ -2,7 +2,7 @@ locals {
   instance_name_prefix       = terraform.workspace
   instance_name              = "${local.instance_name_prefix}-mono"
   instance_type              = var.instance_type
-  instance_image             = "debian_bullseye"
+  instance_image             = var.instance_image
   instance_enable_ipv6       = true
   instance_enable_dynamic_ip = true
   ssh_public_key_name        = "${local.instance_name_prefix}_key"

--- a/roles/stage0/files/scaleway_mono/variables.tf
+++ b/roles/stage0/files/scaleway_mono/variables.tf
@@ -3,6 +3,11 @@ variable "instance_type" {
   default = "DEV1-L"
 }
 
+variable "instance_image" {
+  type    = string
+  default = "debian_bullseye"
+}
+
 variable "ssh_public_key_file" {
   type = string
 }


### PR DESCRIPTION
fixes 

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Terraform plan could not be created\nSTDOUT: \nSTDERR: \nError: Value for undeclared variable\n\nA variable named \"instance_image\" was assigned on the command line, but the\nroot module does not declare a variable of that name. To use this value, add\na \"variable\" block to the configuration.\n\nCOMMAND: /root/hashistack/.direnv/bin/terraform plan -lock=true -input=false -no-color -detailed-exitcode -out /tmp/tmpit9ixe17.tfplan -var ssh_public_key_file=/root/hashistack/inventories/hs_tradent/group_vars/hashistack/secrets/default.key.pub -var instance_type=DEV1-L -var instance_image=debian_bullseye"}