### PR TITLE
Fix vault version

### DIFF
--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # * Version of the vault package to install.
 #
-hs_vault_version: "1.14.2"
+hs_vault_version: "1.14.2-1"
 #
 # * Domain under which vault will be published on the network.
 #


### PR DESCRIPTION
apt-get install -y --download-only vault=1.14.2

Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package vault is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Version '1.14.2' for 'vault' was not found