### PR TITLE
fix(vault): fix vault service fqdn

### DIFF
--- a/roles/vault_vars/defaults/main.yml
+++ b/roles/vault_vars/defaults/main.yml
@@ -38,7 +38,7 @@ hs_vault_node_fqdn: "{{ hs_vault_node_id }}.{{ hs_vault_domain }}"
 # * FQDN of the vault service on the network. Typically the FQDN of the load-balancer
 # if any is set up.
 #
-hs_vault_service_fqdn: "{{ hs_vault_cluster_name }}.{{ hs_vault_domain }}"
+hs_vault_service_fqdn: "{{ hs_vault_domain }}"
 #
 # * URL of the vault service. Used by Terraform from the ansible controller
 # to contact vault for initial configuration.


### PR DESCRIPTION
When the task `Check vault API avalability`, the url returned is bad and the task fails.

Below the vars
* hs_vault_external_url=https://hashistack.hashistack.example.com
* hs_vault_service_fqdn=hashistack.hashistack.example.com
* hs_vault_cluster_name=hashistack
* hs_vault_domain=hashistack.example.com

This PR fixes the var `hs_vault_service_fqdn` .