### PR TITLE
fix(debian12): create archives folder for offline

### DIFF
--- a/playbooks/00_offline_prepare.yml
+++ b/playbooks/00_offline_prepare.yml
@@ -21,6 +21,7 @@
       file:
         path: /var/cache/apt/archives
         state: directory
+        mode: '0755'
 
     - name: Copy rsync dep
       copy:

--- a/playbooks/00_offline_prepare.yml
+++ b/playbooks/00_offline_prepare.yml
@@ -17,6 +17,11 @@
       set_fact:
         rsync_path: "{{ rsync_output.files[0].path }}"
 
+    - name: Ensure archives folder exists
+      file:
+        path: /var/cache/apt/archives
+        state: directory
+
     - name: Copy rsync dep
       copy:
         src: "{{ rsync_path }}"


### PR DESCRIPTION
On Debian12 distribution the playbook `00_offline_prepare.yml` failed with the message

`TASK [Copy rsync dep] *************************************************************************************************************************
fatal: [home-mono]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "changed": false, "checksum": "caa4a9bcf72038e33476f93392c4f51a3a30329a", "msg": "Destination directory /var/cache/apt/archives does not exist"}`

This PR solves this issue.