### PR TITLE
fix(debian12): synch apt repositories

### DIFF
--- a/playbooks/00_offline_prepare.yml
+++ b/playbooks/00_offline_prepare.yml
@@ -48,3 +48,11 @@
         rsync_opts: '--delete -e "ssh -F {{ hs_workspace_root }}/ssh.cfg"'
       tags:
         - sync
+
+    - name: Copy apt sources.list.d/  # noqa: no-same-owner
+      ansible.posix.synchronize:
+        src: /etc/apt/sources.list.d/
+        dest: /etc/apt/sources.list.d/
+        rsync_opts: '--delete -e "ssh -F {{ hs_workspace_root }}/ssh.cfg"'
+      tags:
+        - sync


### PR DESCRIPTION
For Debian 12 offline installation, you need to have apt repositories available to install the packages from apt cache.