### PR TITLE
fix debian 12 offline installation

### DIFF
--- a/roles/consul/meta/main.yml
+++ b/roles/consul/meta/main.yml
@@ -19,6 +19,7 @@ galaxy_info:
     - name: Debian
       versions:
         - bullseye
+        - bookworm
   galaxy_tags:
     - consul
     - hashicorp

--- a/roles/consul/tasks/oraclelinux/main.yml
+++ b/roles/consul/tasks/oraclelinux/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Prepare
+  include_tasks:
+    file: "{{ role_path }}/tasks/common/_prepare.yml"
+    apply:
+      tags: prepare
+  tags:
+    - prepare
+    - online
+
+
+- name: Install
+  include_tasks:
+    file: "{{ role_path }}/tasks/common/_install.yml"
+    apply:
+      tags: install
+  tags:
+    - install
+    - online
+
+- name: Configure
+  include_tasks:
+    file: "{{ role_path }}/tasks/common/_configure.yml"
+    apply:
+      tags: configure
+  when: __hs_consul_is_master
+  tags:
+    - configure
+
+- name: Flush
+  meta: flush_handlers
+

--- a/roles/vault/tasks/common/_prepare.yml
+++ b/roles/vault/tasks/common/_prepare.yml
@@ -7,6 +7,15 @@
   become: false
   delegate_to: localhost
   run_once: true
+  register: vault_download_result
+  tags:
+    - online
+
+- name: "[LOCAL] Assert Vault release archive has been downloaded"
+  assert:
+    that:
+      - vault_download_result.status_code == 200
+    fail_msg: "Download Vault release archive failed with HTTP code: {{ vault_download_result.status_code }}"
   tags:
     - online
 

--- a/roles/vault/tasks/debian/main.yml
+++ b/roles/vault/tasks/debian/main.yml
@@ -6,7 +6,6 @@
       tags: prepare
   tags:
     - prepare
-    - online
 
 - name: Install
   include_tasks:

--- a/roles/vault_vars/vars/debian.yml
+++ b/roles/vault_vars/vars/debian.yml
@@ -2,4 +2,3 @@
 __hs_vault_certs_truststore_dir: "/usr/local/share/ca-certificates"
 __hs_vault_update_trust_command: >-
   update-ca-certificates
-hs_vault_local_cache_dir: "/var/cache"

--- a/roles/vault_vars/vars/debian.yml
+++ b/roles/vault_vars/vars/debian.yml
@@ -2,3 +2,4 @@
 __hs_vault_certs_truststore_dir: "/usr/local/share/ca-certificates"
 __hs_vault_update_trust_command: >-
   update-ca-certificates
+hs_vault_local_cache_dir: "/var/cache"


### PR DESCRIPTION
- Assert that vault release archive download went good  
- remove online tag from roles/vault/tasks/debian/main.yml prepare task
- set hs_vault_local_cache_dir to /var/cache on debian 12